### PR TITLE
Make headers a map of strings

### DIFF
--- a/page.go
+++ b/page.go
@@ -12,7 +12,7 @@ type Page struct {
 	// Method of the request, e.g.: GET
 	Method *string `yaml:"method,omitempty"`
 	// Headers to send with the request
-	Headers map[string][]string `yaml:"headers,omitempty"`
+	Headers map[string]string `yaml:"headers,omitempty"`
 	// UserAgentOptions contains options about the
 	// user agent
 	*UserAgentOptions `yaml:"userAgentOptions,omitempty"`

--- a/page_poller.go
+++ b/page_poller.go
@@ -78,7 +78,9 @@ func New(p *Page) (Poller, error) {
 	if p.Headers == nil {
 		l.Warn().Msg("no headers provided")
 	} else {
-		headers = p.Headers
+		for headerKey, headerVal := range p.Headers {
+			headers[headerKey] = []string{headerVal}
+		}
 		switch hlen := len(p.Headers); {
 		case hlen == 0:
 			l.Warn().Msg("no headers provided")


### PR DESCRIPTION
This poll request makes the `Headers` field of the `page` struct as a just a map of strings.
This makes it easier to write the page yaml file.

Signed-off-by: Elis Lulja <elulja@cisco.com>